### PR TITLE
Register GoogleMapType as a service

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Oh\GoogleMapFormTypeBundle\DependencyInjection;
+
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * This is the class that validates and merges configuration from your app/config files
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        
+        $rootNode = $treeBuilder->root('oh_google_map_form_type');
+
+        // Here you should define the parameters that are allowed to
+        // configure your bundle. See the documentation linked above for
+        // more information on that topic.
+
+        return $treeBuilder;
+    }
+}

--- a/DependencyInjection/OhGoogleMapFormTypeExtension.php
+++ b/DependencyInjection/OhGoogleMapFormTypeExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Oh\GoogleMapFormTypeBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+/**
+ * This is the class that loads and manages your bundle configuration
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
+ */
+class OhGoogleMapFormTypeExtension extends Extension
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.xml');
+    }
+}

--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@ Usage
 
 This bundle contains a new FormType called GoogleMapType which can be used in your forms like so:
 
-    use Oh\GoogleMapFormTypeBundle\Form\Type\GoogleMapType;
-    [...]
-    $builder->add('latlng', new GoogleMapType());
+    $builder->add('latlng', 'oh_google_maps');
 
 On your model you will have to process the latitude and longitude array
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="form.type.oh_google_maps.class">Oh\GoogleMapFormTypeBundle\Form\Type\GoogleMapType</parameter>
+    </parameters>
+
+    <services>
+        <!-- oh_google_maps form type -->
+        <service id="form.type.oh_google_maps" class="%form.type.oh_google_maps.class%">
+            <tag name="form.type" alias="oh_google_maps" />
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
Hi @ollietb, 
I recently used your bundle and I think GoogleMapType must be register as a service.

Before:

```
 use Oh\GoogleMapFormTypeBundle\Form\Type\GoogleMapType;
 [...]
$builder->add('latlng', new GoogleMapType());
```

After:

```
$builder->add('latlng', 'oh_google_maps');
```

Thanks !
